### PR TITLE
Fix arrayref.t on older perl versions

### DIFF
--- a/lib/PerlX/SafeNav.pm
+++ b/lib/PerlX/SafeNav.pm
@@ -66,7 +66,7 @@ sub FETCH {
 
 sub FETCHSIZE {
     my ($self) = @_;
-    @$$self
+    (defined $$self) ? @$$self : 0
 }
 
 package PerlX::SafeNav::HashRef;


### PR DESCRIPTION
As per [issue #3][] and [cpantester matrix][], arrayref.t failed on perl older than 5.20. This narrows down to how they run:

    @$$x

When `$$x` is `undef`

[issue #3]: https://github.com/gugod/PerlX-SafeNav/issues/3
[cpantesters matrix]: http://matrix.cpantesters.org/?dist=PerlX-SafeNav+0.003